### PR TITLE
[Lyrics] Fix DM error

### DIFF
--- a/lyrics/lyrics.py
+++ b/lyrics/lyrics.py
@@ -50,8 +50,11 @@ class Lyrics(commands.Cog):
         self.config.register_guild(**GuildDefault)
 
     async def get_dest(self, ctx, public: bool = False):
-        dest = await self.config.guild(ctx.guild).channel()
-        dest = ctx.guild.get_channel(dest)
+        if not ctx.guild:
+            dest = ctx.author
+        else:
+            dest = await self.config.guild(ctx.guild).channel()
+            dest = ctx.guild.get_channel(dest)
 
         if public:
             if dest is None:


### PR DESCRIPTION
Hey there, with how you had this originally, if someone used the lyrics command in dms to start, there would be no guild that Config could look up for the dest variable.